### PR TITLE
Simple error handler to pfdtool and fixes on save/close without open any file

### DIFF
--- a/PS3TrophyIsGood/Form1.cs
+++ b/PS3TrophyIsGood/Form1.cs
@@ -351,7 +351,7 @@ namespace PS3TrophyIsGood
             tusr = null;
             tconf = null;
             EmptyAllCompoment();
-            if (pathTemp != string.Empty)
+            if (!string.IsNullOrEmpty(pathTemp))
             {
                 Utility.DeleteDirectory(new DirectoryInfo(pathTemp).Parent.FullName);
             }

--- a/PS3TrophyIsGood/Form1.cs
+++ b/PS3TrophyIsGood/Form1.cs
@@ -270,7 +270,6 @@ namespace PS3TrophyIsGood
         private void 存檔ToolStripMenuItem_Click(object sender, EventArgs e)
         {
             SaveFile();
-            RefreashCompoment();
         }
 
         private void 關閉檔案CToolStripMenuItem_Click(object sender, EventArgs e)
@@ -326,6 +325,7 @@ namespace PS3TrophyIsGood
                 {
                     Utility.DeleteDirectory(encPathTemp);
                 }
+                RefreashCompoment();
             }
         }
 

--- a/PS3TrophyIsGood/Form1.cs
+++ b/PS3TrophyIsGood/Form1.cs
@@ -351,7 +351,10 @@ namespace PS3TrophyIsGood
             tusr = null;
             tconf = null;
             EmptyAllCompoment();
-            Utility.DeleteDirectory(new DirectoryInfo(pathTemp).Parent.FullName);
+            if (pathTemp != string.Empty)
+            {
+                Utility.DeleteDirectory(new DirectoryInfo(pathTemp).Parent.FullName);
+            }
             path = string.Empty;
             pathTemp = string.Empty;
             haveBeenEdited = false;

--- a/PS3TrophyIsGood/Utility.cs
+++ b/PS3TrophyIsGood/Utility.cs
@@ -50,6 +50,14 @@ public static class Utility
         proc.StartInfo = procStartInfo;
         proc.Start();
         proc.WaitForExit();
+        string message = proc.StandardOutput.ReadToEnd();
+        if (proc.ExitCode != 0)
+        {
+            throw new Exception("An error ocurred on decrypt trophies. Please check if Microsoft Visual C++ is installed. You can download it at: http://www.microsoft.com/download/en/details.aspx?id=5555");
+        } else if (message != "pfdtool 0.2.3 (c) 2012 by flatz\r\n\r\n")
+        {
+            throw new Exception(message);
+        }
     }
 
     public static void encryptTrophy(string saveDir, string profile)


### PR DESCRIPTION
I did a simple error handler to let user know whats going on pfdtool. I also fixed two problems I introduced on latest PR. About distribute the msvc100.dll, I think it's better to check it's license to avoid problems.