### PR TITLE
Add support for RPCS3 format

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/darkautism/BigEndianTool
 [submodule "TROPHYParser"]
 	path = TROPHYParser
-	url = https://github.com/darkautism/TROPHYParser
+	url = https://github.com/cristi993/TROPHYParser

--- a/PS3TrophyIsGood/Form1.Designer.cs
+++ b/PS3TrophyIsGood/Form1.Designer.cs
@@ -60,6 +60,7 @@
             this.columnHeader7 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader6 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.columnHeader8 = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.isRpcs3Format = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -94,6 +95,7 @@
             this.開啟ToolStripMenuItem,
             this.存檔ToolStripMenuItem,
             this.關閉檔案CToolStripMenuItem,
+            this.isRpcs3Format,
             this.toolStripSeparator1,
             this.關閉ToolStripMenuItem});
             this.檔案ToolStripMenuItem.Name = "檔案ToolStripMenuItem";
@@ -286,6 +288,9 @@
             // 
             resources.ApplyResources(this.columnHeader8, "columnHeader8");
             // 
+            this.isRpcs3Format.Name = "isRpcs3Format";
+            resources.ApplyResources(this.isRpcs3Format, "isRpcs3Format");
+            this.isRpcs3Format.Click += new System.EventHandler(this.toggleRPCS3TrophyFormatToolStripMenuItem_Click);
             // Form1
             // 
             this.AllowDrop = true;
@@ -349,6 +354,7 @@
         private System.Windows.Forms.ColumnHeader columnHeader8;
         private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem1;
         private System.Windows.Forms.ToolStripComboBox toolStripComboBox2;
+        private System.Windows.Forms.ToolStripMenuItem isRpcs3Format;
     }
 }
 

--- a/PS3TrophyIsGood/Form1.cs
+++ b/PS3TrophyIsGood/Form1.cs
@@ -292,7 +292,7 @@ namespace PS3TrophyIsGood
 
         private bool IsTrophyGot(int trophyID)
         {
-            return tpsn[trophyID].HasValue || tusr.trophyTimeInfoTable[trophyID].IsGet;
+            return (!isRpcs3Format.Checked && tpsn[trophyID].HasValue) || tusr.trophyTimeInfoTable[trophyID].IsGet;
         }
 
         private int GetCountBaseTrophiesGot()
@@ -386,7 +386,7 @@ namespace PS3TrophyIsGood
             { // 尚未同步的才可編輯
                 MessageBox.Show(Properties.strings.SyncedTrophyCanNotEdit);
             }
-            else if (tpsn[trophyID].HasValue)
+            else if (tpsn[trophyID].HasValue || (isRpcs3Format.Checked && IsTrophyGot(trophyID)))
             {
                 DeleteTrophy(trophyID, lvi);
             }
@@ -433,9 +433,9 @@ namespace PS3TrophyIsGood
                 path = path_in;
                 pathTemp = Utility.CopyTrophyDirToTemp(path_in);
                 Utility.decryptTrophy(pathTemp);
-                tconf = new TROPCONF(pathTemp);
-                tpsn = new TROPTRNS(pathTemp);
-                tusr = new TROPUSR(pathTemp);
+                tconf = new TROPCONF(pathTemp, isRpcs3Format.Checked);
+                tpsn = new TROPTRNS(pathTemp, isRpcs3Format.Checked);
+                tusr = new TROPUSR(pathTemp, isRpcs3Format.Checked);
 
                 lastSyncTrophyTime = tusr.LastSyncTime;
                 if (DateTime.Compare(tpsn.LastSyncTime, tusr.LastSyncTime) > 0)
@@ -642,6 +642,10 @@ namespace PS3TrophyIsGood
         {
             if (listViewEx1.IsEditing)
                 listViewEx1.EndEditing(true);
+        }
+        private void toggleRPCS3TrophyFormatToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            isRpcs3Format.Checked = !isRpcs3Format.Checked;
         }
     }
 }

--- a/PS3TrophyIsGood/Form1.resx
+++ b/PS3TrophyIsGood/Form1.resx
@@ -186,6 +186,12 @@
   <data name="關閉檔案CToolStripMenuItem.Text" xml:space="preserve">
     <value>&amp;Close File</value>
   </data>
+  <data name="isRpcs3Format.Size" type="System.Drawing.Size, System.Drawing">
+    <value>341, 34</value>
+  </data>
+  <data name="isRpcs3Format.Text" xml:space="preserve">
+    <value>Toggle RPCS3 trophy format</value>
+  </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
     <value>166, 6</value>
   </data>
@@ -2854,6 +2860,12 @@
   </data>
   <data name="&gt;&gt;columnHeader8.Type" xml:space="preserve">
     <value>System.Windows.Forms.ColumnHeader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;isRpcs3Format.Name" xml:space="preserve">
+    <value>isRpcs3Format</value>
+  </data>
+  <data name="&gt;&gt;isRpcs3Format.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>Form1</value>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Best ps3 trophy editor ever
 	git submodule init
 	git submodule update --recursive
 
-After that, you can use visual studio to compile this project.
+After that, you can use visual studio 2019+ to compile this project (with .NET desktop development support).
 
 ## Download
 


### PR DESCRIPTION
Add support to read/write [RPCS3](https://rpcs3.net/) emulator trophy format:
- add File menu item to toggle the format support
![image](https://github.com/user-attachments/assets/ca09cfc2-76c9-41d1-8f4f-b223e1568ede)
- pass around the `isRpcs3Format` value to the constructors for `TROPCONF`, `TROPTRNS` and `TROPUSR`
    - depends on: https://github.com/darkautism/TROPHYParser/pull/7
- fix `IsTrophyGot` and trophy lock/unlock for rpcs3 case

**TODO**: update git submodule once https://github.com/darkautism/TROPHYParser/pull/7 is merged

Tested with the following titles: NPWR00745_00 (Dante's Inferno), NPWR00801_00 (God of War II), NPWR00867_00 (Red Dead Redemption), NPWR01125_00 (NIER), NPWR02071_00 (God of War: Ghost of Sparta), NPWR03073_00 (The Last of Us), NPWR03581_00 (Sly Cooper: Thieves in Time)

Note: minimum supported RPCS3 version is [0.0.28](https://github.com/RPCS3/rpcs3/releases/tag/v0.0.28)

Closes #17 and #24 